### PR TITLE
Only depend on nlopt installation for Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,24 +37,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/0001-download-nlopt-w-curl.patch
+++ b/recipe/0001-download-nlopt-w-curl.patch
@@ -1,0 +1,22 @@
+--- a/configure	2017-08-22 07:59:12.000000000 -0300
++++ b/configure	2018-01-16 16:41:25.378540069 -0200
+@@ -3298,7 +3298,7 @@
+ 
+    ## Download NLopt source code
+    ## curl -O http://ab-initio.mit.edu/nlopt/nlopt-${NLOPT_VERSION}.tar.gz
+-   $("${R_HOME}/bin/Rscript" --vanilla -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}')")
++   $("${R_HOME}/bin/Rscript" --vanilla -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}', method='curl', extra='-L')")
+ 
+    ## Extract NLopt source code and remove .tar.gz
+    ## tar -xzvf nlopt-${NLOPT_VERSION}.tar.gz
+--- a/configure.ac	2014-08-02 15:11:56.000000000 -0300
++++ b/configure.ac	2018-01-16 16:40:42.258540446 -0200
+@@ -123,7 +123,7 @@
+ 
+    ## Download NLopt source code
+    ## curl -O http://ab-initio.mit.edu/nlopt/nlopt-${NLOPT_VERSION}.tar.gz
+-   $("${R_HOME}/bin/Rscript" --vanilla -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}')")
++   $("${R_HOME}/bin/Rscript" --vanilla -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}', method='curl', extra='-L')")
+ 
+    ## Extract NLopt source code and remove .tar.gz
+    ## tar -xzvf nlopt-${NLOPT_VERSION}.tar.gz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 84225b993cb1ef7854edda9629858662cc8592b0d1344baadea4177486ece1eb
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
 
   rpaths:
@@ -25,14 +25,14 @@ build:
 requirements:
   build:
     - r-base
-    - {{native}}nlopt
+    - {{native}}nlopt      # [win]
     - posix                # [win]
     - {{native}}toolchain  # [win]
     - gcc                  # [not win]
 
   run:
     - r-base
-    - {{native}}nlopt
+    - {{native}}nlopt      # [win]
 
 test:
   commands:
@@ -55,3 +55,4 @@ extra:
   recipe-maintainers:
     - johanneskoester
     - bgruening
+    - jdblischak

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
     - https://cran.r-project.org/src/contrib/nloptr_{{ version }}.tar.gz
     - https://cran.r-project.org/src/contrib/Archive/nloptr/nloptr_{{ version }}.tar.gz
   sha256: 84225b993cb1ef7854edda9629858662cc8592b0d1344baadea4177486ece1eb
+  patches:
+    - 0001-download-nlopt-w-curl.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,9 +52,12 @@ about:
     and compiled from the NLopt website.'
 
   license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-3'  # [win]
 
 extra:
   recipe-maintainers:
     - johanneskoester
     - bgruening
     - jdblischak
+    - rvalieris


### PR DESCRIPTION
On Unix-like systems, nloptr downloads and compiles nlopt during installation. This PR makes the recipe consistent with the one in defaults, which the conda solver chooses since it is simpler.

https://github.com/AnacondaRecipes/r-nloptr-feedstock/blob/master/recipe/meta.yaml#L44

This r-nloptr problem is stalling multiple of my PRs, e.g.:

https://github.com/conda-forge/r-bradleyterry2-feedstock/pull/1
https://github.com/conda-forge/r-car-feedstock/pull/1
https://github.com/bioconda/bioconda-recipes/pull/6873

Looking at the initial submission to staged-recipes, there was no discussion to motivate r-nloptr having nlopt as a dependency on linux and osx.

https://github.com/conda-forge/staged-recipes/pull/2784